### PR TITLE
fix:safariでfaviconが表示されない問題を修正

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -18,7 +18,7 @@
     <link rel="manifest" href="/manifest.json">
     <link rel="icon" href="<%= asset_path 'icon.svg' %>" type="image/png">
     <link rel="icon" href="<%= asset_path 'icon.svg' %>" type="image/svg+xml">
-    <link rel="apple-touch-icon" href="/icon.png">
+    <link rel="apple-touch-icon" href="<%= asset_path 'icon.png' %>">
     <%= stylesheet_link_tag "tailwind", "inter-font", "data-turbo-track": "reload" %>
     <%#= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= javascript_include_tag "application", "data-turbo-track": "reload", type: "module" %>


### PR DESCRIPTION
# 概要
favicon修正

## 内容
safariでfaviconが表示されない為pathを明示するコードへ変更しました。