### PR TITLE
OGPフォントサイズの拡大

### DIFF
--- a/app/controllers/concerns/ogp_creator.rb
+++ b/app/controllers/concerns/ogp_creator.rb
@@ -4,7 +4,7 @@ class OgpCreator
   GRAVITY = "center"
   TEXT_POSITION = "0,0"
   FONT = "./app/assets/fonts/Zen_Antique/ZenAntique-Regular.ttf"
-  FONT_SIZE = 55
+  FONT_SIZE = 60
   INDENTION_COUNT = 16
   ROW_LIMIT = 8
 


### PR DESCRIPTION
### OGP画像のフォントサイズ調整
- フォントサイズを`55` →` 60`へ変更しました。